### PR TITLE
ci: 🔧 rename release config to .mjs

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -22,7 +22,7 @@ const releseNotesTypes = [
 ];
 
 const config = {
-  branches: ['master'],
+  branches: ['master`'],
   plugins: [
     [
       // This plugin is responsible for analyzing the commit messages and determining the type of release to be made.


### PR DESCRIPTION
Renamed release.config.js to release.config.mjs and updated the branch name in the config from 'master' to 'master`'.