### PR TITLE
fix: 🐛 switch to CommonJS export in release.config.js

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -70,4 +70,4 @@ const config = {
   ],
 };
 
-export default config;
+module.exports = config;


### PR DESCRIPTION
Replaces ES module export with CommonJS module.exports for compatibility with environments expecting CommonJS syntax.