### PR TITLE
fix: 🐛 Update release workflow to use BOT_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,5 +37,5 @@ jobs:
           additional-packages: |
             ['conventional-changelog-conventionalcommits@6', '@semantic-release/changelog', '@semantic-release/git']
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Switched to BOT_GITHUB_TOKEN for repository checkout and environment variables in the release workflow. Also set fetch-depth to 0 for full git history during checkout.