### PR TITLE
chore: 🔧 update release config and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,34 @@
 
 * 🐛 rename release config file to .js extension ([a09c40b](https://github.com/SandeepK1729/jarvis/commit/a09c40b9d742dbf1a1e6d5ee826ff16402cf7c2d))
 * 🐛 switch to CommonJS export in release.config.js ([#27](https://github.com/SandeepK1729/jarvis/issues/27)) ([fa2a6ad](https://github.com/SandeepK1729/jarvis/commit/fa2a6ad4ef284f08d8f47bca1142af7809b56cfa))
+* 🐛 Update branch configuration in release.config.js ([7de7566](https://github.com/SandeepK1729/jarvis/commit/7de7566e1414255da074671495094f2b5e2827fb))
+
+## [0.1.2](https://github.com/SandeepK1729/jarvis/compare/v0.1.1...v0.1.2) (2025-09-02)
+
+
+### Bug Fixes
+
+* 🐛 resolve build issue and setup CI github action  ([#24](https://github.com/SandeepK1729/jarvis/issues/24)) ([9ad6aa9](https://github.com/SandeepK1729/jarvis/commit/9ad6aa955e43fff280bd5a71511a19b46c7e8149))
+
+# [0.1.0](https://github.com/SandeepK1729/jarvis/compare/v0.0.1...v0.1.0) (2025-09-02)
+
+
+### Features
+
+* ✨ update alias listing to show command ([#20](https://github.com/SandeepK1729/jarvis/issues/20)) ([199e517](https://github.com/SandeepK1729/jarvis/commit/199e517b705fa128ea3d9ae7e0b26f3e50a24aaf))
+
+## [0.0.1](https://github.com/SandeepK1729/jarvis/releases/tag/v0.0.1) (2025-09-01)
+
+### Initial Setup
+
+* build: 🔧 Initialize project with TypeScript and config files by @SandeepOCT in https://github.com/SandeepK1729/jarvis/pull/5
+* build: 🔧 setup npm registry config and update package name by @SandeepK1729 in https://github.com/SandeepK1729/jarvis/pull/17
+
+### Features
+
+* feat: ✨ implement core logic for alias and running by @SandeepK1729 in https://github.com/SandeepK1729/jarvis/pull/14
+
+### CI
+
+* ci: 🔧 configure dependabot by @SandeepK1729 in https://github.com/SandeepK1729/jarvis/pull/9
+* ci: 🔧 setup PR lint for conventional commit by @SandeepK1729 in https://github.com/SandeepK1729/jarvis/pull/16

--- a/release.config.js
+++ b/release.config.js
@@ -60,7 +60,7 @@ const config = {
       // This plugin is responsible for committing the changes made by the previous plugins.
       '@semantic-release/git',
       {
-        assets: ['CHANGELOG.md', 'package.json', 'package-lock.json'],
+        assets: ['CHANGELOG.md', 'package.json', 'pnpm-lock.yaml'],
         message:
           'chore(release): :rocket: ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
       },


### PR DESCRIPTION
- update release config to include `pnpm-lock.yml` instead of `package-lock.json`
- included CHANGELOG of previous releases