### PR TITLE
fix: 🐛  Switch to semantic-release-github-pullrequest plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           # The branches on which releases should happen. https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#branches
           additional-packages: |
-            ['conventional-changelog-conventionalcommits@6', '@semantic-release/changelog', '@semantic-release/git']
+            ['conventional-changelog-conventionalcommits@6', '@semantic-release/changelog', '@semantic-release/git', 'semantic-release-github-pullrequest']
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release.config.js
+++ b/release.config.js
@@ -61,12 +61,16 @@ const config = {
     '@semantic-release/npm',
     [
       // This plugin is responsible for committing the changes made by the previous plugins.
-      '@semantic-release/git',
-      {
-        assets: ['CHANGELOG.md', 'package.json', 'package-lock.json'],
-        message:
-          'chore(release): :rocket: ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
-      },
+      // '@semantic-release/git',
+      // {
+      //   assets: ['CHANGELOG.md', 'package.json', 'package-lock.json'],
+      //   message:
+      //     'chore(release): :rocket: ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
+      // },
+      "semantic-release-github-pullrequest", {
+        assets: ["CHANGELOG.md"],
+        baseRef: "prerelease"
+      }
     ],
     // This plugin is resposible for creating Github releases and update included PR's with the release information.
     '@semantic-release/github',


### PR DESCRIPTION
Replaces @semantic-release/git with semantic-release-github-pullrequest in release workflow and config. This change enables release notes and changelog updates to be committed via pull requests to the 'prerelease' branch, improving release management and review.